### PR TITLE
Add initial training research docs and wiki plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# Agent_Hub
+# Agent Hub
+
+Agent Hub is an evolving workspace for research on model training, memory interfaces, and hardware-aware optimization.
+
+## Documentation
+- [Training Research Directions](docs/training_research.md)
+- [Wiki Structure Plan](docs/wiki_structure.md)
+
+Contributions should keep documentation clear and concise. The GitHub wiki is planned to mirror the docs directory and provide quick navigation.

--- a/docs/training_research.md
+++ b/docs/training_research.md
@@ -1,0 +1,24 @@
+# Training Research Directions
+
+This document outlines initial high-level training options and research ideas for the Agent Hub project.
+
+## Goals
+- Explore hardware-conscious training strategies.
+- Investigate memory-layer interfaces and bus statistics for optimization.
+- Design auto-tuning mechanisms that adapt to resource constraints.
+
+## High-Level Training Options
+1. **Transfer Learning Pipelines**: Provide templates for fine-tuning pre-trained models on new domains.
+2. **Curriculum Learning Modules**: Implement schedulers that gradually increase task difficulty.
+3. **Distributed Training Hooks**: Offer abstraction layers for multi-GPU or multi-node setups.
+
+## Memory Layer Engagement
+- Implement pluggable memory modules with configurable retention policies.
+- Track read/write patterns to inform memory pruning and caching strategies.
+- Expose interfaces for collecting bus utilization metrics during training.
+
+## Hardware-Aware Auto-Tuning
+- Profile GPU/CPU utilization and dynamically adjust batch sizes or precision.
+- Experiment with mixed-precision and sparsity-aware kernels.
+- Collect interface and bus statistics to guide bandwidth-friendly scheduling.
+

--- a/docs/wiki_structure.md
+++ b/docs/wiki_structure.md
@@ -1,0 +1,13 @@
+# Wiki Structure Plan
+
+This file proposes an initial structure for the GitHub wiki.
+
+## Suggested Pages
+- **Home**: Overview and project goals.
+- **Getting Started**: Environment setup, contribution guidelines.
+- **Training Research**: Link to in-repo docs on training options and memory layer experiments.
+- **Hardware Metrics**: Documentation of interface and bus statistics collection.
+- **Auto-Tuning Strategies**: Guides for hardware-aware training and resource optimization.
+- **Changelog**: Summary of major updates and milestones.
+
+Each page should be concise, link to relevant repo files, and stay synchronized with the main documentation.


### PR DESCRIPTION
## Summary
- outline high-level training research directions
- draft structure for a future GitHub wiki
- refresh main README with documentation links

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc95aa33948330aef24c6638431344