### PR TITLE
docs: add interface roadmap

### DIFF
--- a/docs/INTERFACE_ROADMAP.md
+++ b/docs/INTERFACE_ROADMAP.md
@@ -1,0 +1,31 @@
+Agents Running Wild — Interface Roadmap
+Updated: 2025-09-07
+
+This roadmap consolidates user-facing interface concepts to guide a unified, accessible experience across the service, tray app, and debug tooling.
+
+Short-term (0–3 months)
+- Guided micro-tutorials for first-time features
+- Micro-satisfaction elements (light animations, haptic feedback)
+- Contextual tray actions with recent commands
+- Inline doc hints and contextual tooltips
+- Command palette/quick-action menu in tray app
+
+Medium-term (3–6 months)
+- Multi-modal input (voice, stylus, gesture)
+- Predictive autoflow suggestions
+- Progressive disclosure interface pattern
+- Tiled debug surface with rearrangeable panels
+- Live linting for macros and one-click tool sandboxing
+- Integrated monitoring/analytics modules
+- Voice/terminal parity for key commands
+
+Long-term (6+ months)
+- Timeline-based activity stream with timeline scrubber
+- Dynamic flow view and declarative recipe builder
+- Real-time collaboration cues and shareable debug sessions
+- Cross-device handoff of in-progress sessions
+- Minimal offline docs packaged with app
+- Inline node graph visualization of agent events
+- Comprehensive debug session export/import
+- Dynamic "what-if" runs branching from historical states
+

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,6 @@
 Agents Running Wild — Roadmap
 Updated: 2025-09-07
+See [Interface Roadmap](INTERFACE_ROADMAP.md) for user-facing UI and tooling plans.
 
 Near‑term (Weeks)
 - Self‑learning UI polish: apply buttons per suggestion with rationale + confidence.


### PR DESCRIPTION
## Summary
- document phased interface roadmap for upcoming UI, navigation, and tooling work
- link main roadmap to the new interface roadmap

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdeb969d588330b49fa0b04b8c80ee