### PR TITLE
Use cargo-nextest for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,9 @@ Workflow
 3. Update docs and regenerate the workspace status page.
 4. Keep commits focused and messages descriptive.
 
+Prerequisites
+- Install `cargo-nextest`: `cargo install cargo-nextest`
+
 Commands
 ```bash
 cargo fmt --all -- --check

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -13,8 +13,9 @@ Key ideas
 
 Useful commands
 ```bash
+cargo install cargo-nextest
 cargo build --workspace --all-targets --locked
-cargo test  --workspace --locked
+cargo nextest run --workspace --locked
 ```
 
 Rolling optimizations

--- a/nextest.toml
+++ b/nextest.toml
@@ -1,0 +1,6 @@
+[profile.default]
+# Use default settings for local runs.
+
+[profile.ci]
+# Run all tests in CI without stopping at the first failure.
+fail-fast = false

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -20,8 +20,8 @@ if (-not $DebugBuild) { $cargoArgs += '--release' }
 & cargo @cargoArgs
 
 if (-not $NoTests) {
-  Info 'Running tests (workspace)'
-  & cargo test --workspace --locked
+  Info 'Running tests (workspace via nextest)'
+  & cargo nextest run --workspace --locked
 }
 
 Info 'Done.'

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -21,8 +21,8 @@ else
 fi
 
 if [[ $run_tests -eq 1 ]]; then
-  echo "[build] Running tests"
-  cargo test --workspace
+  echo "[build] Running tests (nextest)"
+  cargo nextest run --workspace
 fi
 
 echo "[build] Done."

--- a/scripts/setup.ps1
+++ b/scripts/setup.ps1
@@ -41,7 +41,7 @@ Title 'Build workspace (release)'
 
 if ($RunTests) {
   Title 'Run tests (workspace)'
-  & cargo test --workspace --locked
+  & cargo nextest run --workspace --locked
 }
 
 Title 'Generate workspace status page'

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -46,7 +46,7 @@ title "Build workspace (release)"
 
 if [[ $run_tests -eq 1 ]]; then
   title "Run tests (workspace)"
-  cargo test --workspace --locked
+  cargo nextest run --workspace --locked
 fi
 
 title "Generate workspace status page"

--- a/scripts/test.ps1
+++ b/scripts/test.ps1
@@ -4,5 +4,5 @@ $ErrorActionPreference = 'Stop'
 
 if (-not (Get-Command cargo -ErrorAction SilentlyContinue)) { Write-Error 'Rust `cargo` not found in PATH.'; exit 1 }
 
-Write-Host '[test] Running cargo tests (workspace)' -ForegroundColor Cyan
-cargo test --workspace --locked
+Write-Host '[test] Running cargo nextest (workspace)' -ForegroundColor Cyan
+cargo nextest run --workspace --locked

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
 command -v cargo >/dev/null || { echo 'cargo not found'; exit 1; }
-echo "[test] Running cargo tests (workspace)"
-cargo test --workspace
+echo "[test] Running cargo nextest (workspace)"
+cargo nextest run --workspace


### PR DESCRIPTION
## Summary
- add `nextest.toml` for default and CI profiles
- switch CI scripts to `cargo nextest run`
- document `cargo-nextest` install in contributor and developer guides

## Testing
- `cargo nextest run --workspace --locked` *(fails: linking with `cc` for `arw-tray`)*
- `cargo nextest run --workspace --locked --exclude arw-tray`


------
https://chatgpt.com/codex/tasks/task_e_68bdf9d2259c833099daae0472223665