### PR TITLE
chore: add cargo-dist config and installers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,8 @@
+[dist]
+# Targets for which cargo-dist will produce archives/installers
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc"
+]

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,42 @@
+name: Dist
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  build-installers:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: macos-latest
+            target: aarch64-apple-darwin
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install cargo-dist
+        run: cargo install cargo-dist --locked
+      - name: Build installers
+        run: cargo dist build --target ${{ matrix.target }} --installer --no-confirm
+      - name: Upload installers
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}-dist
+          path: target/dist/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,14 @@ lto = "thin"
 codegen-units = 1
 debug = 0
 incremental = false
+
+[workspace.metadata.dist]
+# Configuration for cargo-dist distribution tooling
+cargo-dist-version = "0.30.0"
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "x86_64-apple-darwin",
+    "aarch64-apple-darwin",
+    "x86_64-pc-windows-msvc"
+]
+installers = ["shell", "powershell", "msi", "pkg"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ Key goals
 - Tool registration via macros + inventory
 - Clear packaging for sharing/upload
 
+Download and Install
+- Grab the latest binaries from the GitHub Releases page. Installers are built for Windows, macOS, and Linux using `cargo-dist`.
+- Windows: download the `.msi` and run the installer.
+- macOS: download the `.pkg` or `.tar.xz` archive and install the binary.
+- Linux: download the `.tar.xz` archive, extract it, and place the binaries on your `PATH`.
+
 Quickstart
 - One‑shot setup (build, docs, package):
   - Windows: `powershell -ExecutionPolicy Bypass -File scripts/setup.ps1`


### PR DESCRIPTION
## Summary
- configure cargo-dist for multi-platform builds
- add workflow to build installers
- document download and install steps

## Testing
- `cargo check -p arw-cli`

------
https://chatgpt.com/codex/tasks/task_e_68bdf9d8bf548330bedcf6c00ffb06e2