### PR TITLE
docs: add Nix quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Key goals
 - Clear packaging for sharing/upload
 
 Quickstart
+- Install [Nix](https://nixos.org/download.html) and use it as the entry point for building, testing, and packaging:
+  - `nix develop` to enter a shell with all dependencies
+  - Run commands directly: `nix develop --command cargo build`, `nix develop --command cargo test`, `nix develop --command scripts/package.sh`, etc.
 - One‑shot setup (build, docs, package):
   - Windows: `powershell -ExecutionPolicy Bypass -File scripts/setup.ps1`
   - Linux/macOS: `bash scripts/setup.sh`


### PR DESCRIPTION
## Summary
- recommend using `nix develop` as the entry point for building, testing, and packaging
- show example commands using `nix develop --command`

## Testing
- `cargo test` *(fails: The system library `glib-2.0` required by crate `glib-sys` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfbc77aa48330927b0513c7469a74