### PR TITLE
ci: add nix build and test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,19 @@ jobs:
           name: arw-linux-bundle
           path: dist/*.zip
 
+  nix-build-test:
+    name: Nix Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v25
+      - name: Build in Nix
+        run: nix develop --command cargo build --workspace --all-targets --locked
+      - name: Test in Nix
+        run: nix develop --command cargo test --workspace --locked
+
   docs-check:
     name: Docs Build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- run cargo build and test within a nix develop environment on ubuntu

## Testing
- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --locked`


------
https://chatgpt.com/codex/tasks/task_e_68bdfbcc6d8883308316ab206d7c9c68